### PR TITLE
Fix buffer underflow in drawPlusMask

### DIFF
--- a/src/Sprites.cpp
+++ b/src/Sprites.cpp
@@ -334,9 +334,9 @@ void Sprites::drawBitmap(int16_t x, int16_t y,
         : [xi] "+&r" (xi),
         [yi] "+&r" (yi),
         [sRow] "+&d" (sRow), // CPI requires an upper register
-        [data] "+&r" (data),
-        [mask_data] "+&r" (mask_data),
-        [bitmap_data] "+&r" (bitmap_data)
+        [data] "=&r" (data),
+        [mask_data] "=&r" (mask_data),
+        [bitmap_data] "=&r" (bitmap_data)
         :
         [x_count] "r" (rendered_width),
         [y_count] "r" (loop_h),

--- a/src/Sprites.cpp
+++ b/src/Sprites.cpp
@@ -285,19 +285,23 @@ void Sprites::drawBitmap(int16_t x, int16_t y,
 
 
         // FIRST PAGE
-        "ld %[data], %a[buffer_ofs]\n"
         // if sRow >= 0
         "tst %[sRow]\n"
-        "brmi end_first_page\n"
+        "brmi skip_first_page\n"
+        "ld %[data], %a[buffer_ofs]\n"
         // then
         "com %A[mask_data]\n"
         "and %[data], %A[mask_data]\n"
         "or %[data], %A[bitmap_data]\n"
-
-        "end_first_page:\n"
         // update buffer, increment
         "st %a[buffer_ofs]+, %[data]\n"
+        "jmp end_first_page\n"
 
+        "skip_first_page:\n"
+        // since no ST Z+ when skipped we need to do this manually
+        "adiw %[buffer_ofs], 1\n"
+
+        "end_first_page:\n"
 
         // "x_loop_next:\n"
         "dec %[xi]\n"

--- a/src/Sprites.cpp
+++ b/src/Sprites.cpp
@@ -347,7 +347,10 @@ void Sprites::drawBitmap(int16_t x, int16_t y,
         [sprite_ofs_jump] "r" ((w-rendered_width)*2),
         [yOffset] "r" (yOffset),
         [mul_amt] "r" (mul_amt)
-        :
+        // declaring an extra high register clobber here for some reason
+        // prevents a compile error for some sketches:
+        // can't find a register in class 'LD_REGS' while reloading 'asm'
+        : "r24"
       );
       break;
   }


### PR DESCRIPTION
When sRow == -1 drawPlusMask can cause buffer underflow if it's
interrupted by an interrupt that changes memory that it's in the middle
of writing.  Of course it shouldn't be writing to this memory at all.

This fixes the issue.

Also resolves a pesky issues with register pressure on the upper registers that sometimes prevent a successful compile.