### PR TITLE
Make drawLine smarter on PIXEL_SAFE_MODE

### DIFF
--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -440,7 +440,7 @@ class Arduboy2Base : public Arduboy2Core
    * This function returns true if x is in the interval [0, WIDTH) and y is in
    * the interval [0, HEIGHT).
    */
-  bool validPixel(int16_t x, int16_t y) {
+  static constexpr bool validPixel(int16_t x, int16_t y) {
     return !(x < 0 || x > (WIDTH-1) || y < 0 || y > (HEIGHT-1));
   }
 

--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -431,6 +431,20 @@ class Arduboy2Base : public Arduboy2Core
   void display(bool clear);
 
   /** \brief
+   * Tells whether a given coordinate points to a valid pixel.
+   * 
+   * \param x The X coordinate of the pixel.
+   * \param y The Y coordinate of the pixel.
+   * 
+   * \details
+   * This function returns true if x is in the interval [0, WIDTH) and y is in
+   * the interval [0, HEIGHT).
+   */
+  bool validPixel(int16_t x, int16_t y) {
+    return !(x < 0 || x > (WIDTH-1) || y < 0 || y > (HEIGHT-1));
+  }
+
+  /** \brief
    * Set a single pixel in the display buffer to the specified color.
    *
    * \param x The X coordinate of the pixel.
@@ -443,6 +457,10 @@ class Arduboy2Base : public Arduboy2Core
    * If the `color` parameter isn't included, the pixel will be set to WHITE.
    */
   void drawPixel(int16_t x, int16_t y, uint8_t color = WHITE);
+
+  // Draw a pixel without checking.
+  // (Not officially part of the API)
+  void drawPixelRaw(int16_t x, int16_t y, uint8_t color);
 
   /** \brief
    * Returns the state of the given pixel in the screen buffer.


### PR DESCRIPTION
The current drawLine leaves all the pixel-safety checks to drawPixel, which is not quite optimal for off-screen lines and partially off-screen lines. This commit changes its behavior by having it skip the draw when both ends are off-screen, and also skip when the "current pixel" goes from on-screen to off-screen.

To achieve this end some API changes are done to drawPixel, since it after all does not tell whether a draw has been attempted. A (very internal; not in header) drawPixelMaybe function is now composed of drawPixel's checking part, and a drawPixelRaw for a complete absense of checks in other "safe" functions. The drawPixel signature is unchanged; it is hoped that drawPixelMaybe would be inlined, its returns stripped, exposing the drawPixelRaw call as a tail call.

This PR is probably very unnecessary; I wrote it so that I can stop thinking about how slow a newton solver would be on the Arduboy.