### PR TITLE
Move avr/wdt.h include to cpp file

### DIFF
--- a/src/Arduboy2Core.cpp
+++ b/src/Arduboy2Core.cpp
@@ -6,6 +6,8 @@
 
 #include "Arduboy2Core.h"
 
+#include <avr/wdt.h>
+
 const uint8_t PROGMEM lcdBootProgram[] = {
   // boot defaults are commented out but left here in case they
   // might prove useful for reference

--- a/src/Arduboy2Core.h
+++ b/src/Arduboy2Core.h
@@ -10,7 +10,6 @@
 #include <Arduino.h>
 #include <avr/power.h>
 #include <avr/sleep.h>
-#include <avr/wdt.h>
 #include <limits.h>
 
 


### PR DESCRIPTION
`avr/wdt.h` is only used in the definition of the `Arduboy2Core::exitToBootloader` and not in the definition of `Arduboy2Core`, therefore it makes sense to only include it in the `.cpp` file in which it is used and not in the header file.