### PR TITLE
optimized drawPixel() and fixed Arduino IDE 1.8.6/1.8.7 issue

### DIFF
--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -442,7 +442,7 @@ class Arduboy2Base : public Arduboy2Core
    * specified color. The values WHITE or BLACK can be used for the color.
    * If the `color` parameter isn't included, the pixel will be set to WHITE.
    */
-  void drawPixel(int16_t x, int16_t y, uint8_t color = WHITE);
+  static void drawPixel(int16_t x, int16_t y, uint8_t color = WHITE);
 
   /** \brief
    * Returns the state of the given pixel in the screen buffer.


### PR DESCRIPTION
The new compiler In Arduino IDE 1.8.6/1.8.7 has an optimization glitch where it fails to see the difference between a data structure in RAM and in PROGMEM when the data is the same and optimizes one out. 

drawPixel() is unable to fetch the correct pixel mask from the bitshift_left array in PROGMEM causing junk to be drawn

The bitshift_left[] array has now been optimised out and drawPixel() will function properly. The optimisation uses the same number of cycles and saves 6 bytes

drawPixel() has also been made static so the Arduboy object pointer is no longer needlesly passed on to drawPixel()  saving more bytes

DrawPixel has