### PR TITLE
Prevent Error: symbol loopto is already defined with -O3 optimization.

### DIFF
--- a/src/Arduboy2.cpp
+++ b/src/Arduboy2.cpp
@@ -678,7 +678,7 @@ void Arduboy2Base::fillScreen(uint8_t color)
     "ldi %[color], 0xFF\n"
     // counter = 0
     "clr __tmp_reg__\n"
-    "loopto:\n"
+    "1:\n"
     // (4x) push zero into screen buffer,
     // then increment buffer position
     "st Z+, %[color]\n"
@@ -689,7 +689,7 @@ void Arduboy2Base::fillScreen(uint8_t color)
     "inc __tmp_reg__\n"
     // repeat for 256 loops
     // (until counter rolls over back to 0)
-    "brne loopto\n"
+    "brne 1b\n"
     : [color] "+d" (color),
       "+z" (bPtr)
     :

--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -580,7 +580,7 @@ class Arduboy2Base : public Arduboy2Core
    *
    * \param color The fill color (optional; defaults to WHITE).
    */
-  void fillScreen(uint8_t color = WHITE);
+  void fillScreen(uint8_t color = WHITE) __attribute__ ((noinline));
 
   /** \brief
    * Draw a rectangle with rounded corners.

--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -580,7 +580,7 @@ class Arduboy2Base : public Arduboy2Core
    *
    * \param color The fill color (optional; defaults to WHITE).
    */
-  void fillScreen(uint8_t color = WHITE) __attribute__ ((noinline));
+  void fillScreen(uint8_t color = WHITE);
 
   /** \brief
    * Draw a rectangle with rounded corners.


### PR DESCRIPTION
I am doing a custom command line compile and upload for my 3D Arduboy project rush.
https://github.com/blakewford/rush

In order to fit all this code on the device, I am using -O3 optimization. At that level, some how the compiler decides that the label within the fillScreen asm block would work optimally if duplicated. I searched through the Arduboy2 codebase and found the noinline attribute on another function. 

Currently my project points to my fork, but I would love to get back onto a mainstream version if you think this code has a place in the final product.