### PR TITLE
Fix missing Print::write overloads

### DIFF
--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -1390,6 +1390,7 @@ class Arduboy2 : public Print, public Arduboy2Base
    *
    * \see Arduboy2::write()
    */
+   using Print::write;
 
   /** \brief
    * Display the boot logo sequence using printed text instead of a bitmap.


### PR DESCRIPTION
**Problem:**
The overloading of `Print::write` was previously causing the other overloads of `write` to be hidden.
For more information on this behaviour, see the following StackOverflow question:
https://stackoverflow.com/questions/1628768

**Solution:**
The solution uses a `using`-declaration to bring the `Print::write` overloads into `Arduboy2`'s scope.
For more information on this usage of a `using`-declaration, see the following cppreference page:
https://en.cppreference.com/w/cpp/language/using_declaration#In_class_definition