### PR TITLE
Make 'writeUnitName' const-correct

### DIFF
--- a/src/Arduboy2.cpp
+++ b/src/Arduboy2.cpp
@@ -1096,7 +1096,7 @@ uint8_t Arduboy2Base::readUnitName(char* name)
   return dest;
 }
 
-void Arduboy2Base::writeUnitName(char* name)
+void Arduboy2Base::writeUnitName(const char* name)
 {
   bool done = false;
   uint8_t dest = EEPROM_UNIT_NAME;

--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -1169,7 +1169,7 @@ class Arduboy2Base : public Arduboy2Core
    *
    * \see readUnitName() writeUnitID() Arduboy2::bootLogoExtra()
    */
-  void writeUnitName(char* name);
+  void writeUnitName(const char* name);
 
   /** \brief
    * Read the "Show Boot Logo" flag in system EEPROM.


### PR DESCRIPTION
Without this, an attempt to pass a string literal or an array of `const` `char` as an argument will create a warning:
* `warning: invalid conversion from 'const char*' to 'char*' [-fpermissive]`
* `warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]`

In a standard C++ environment, these warnings would be compiler errors.

This change is backwards compatible because adding `const` _decreases_ restrictions on the input parameter.