### PR TITLE
Changes for Arduboy FX

### DIFF
--- a/src/Arduboy2.h
+++ b/src/Arduboy2.h
@@ -53,6 +53,8 @@
 #define SYS_FLAG_SHOW_LOGO_MASK _BV(SYS_FLAG_SHOW_LOGO)
 #define SYS_FLAG_SHOW_LOGO_LEDS 2  // Flash the RGB led during the boot logo
 #define SYS_FLAG_SHOW_LOGO_LEDS_MASK _BV(SYS_FLAG_SHOW_LOGO_LEDS)
+#define SYS_FLAG_POWERON_MENU 7  // Start with FX loader menu after power on
+#define SYS_FLAG_POWERON_MENU_MASK _BV(SYS_FLAG_POWERON_MENU)
 
 /** \brief
  * Start of EEPROM storage space for sketches.

--- a/src/Arduboy2Core.cpp
+++ b/src/Arduboy2Core.cpp
@@ -233,7 +233,7 @@ void Arduboy2Core::bootSPI()
 }
 
 // Write to the SPI bus (MOSI pin)
-void Arduboy2Core::SPItransfer(uint8_t data)
+uint8_t Arduboy2Core::SPItransfer(uint8_t data)
 {
   SPDR = data;
   /*
@@ -244,6 +244,7 @@ void Arduboy2Core::SPItransfer(uint8_t data)
    */
   asm volatile("nop");
   while (!(SPSR & _BV(SPIF))) { } // wait
+  return SPDR;
 }
 
 void Arduboy2Core::safeMode()

--- a/src/Arduboy2Core.h
+++ b/src/Arduboy2Core.h
@@ -400,7 +400,7 @@ class Arduboy2Core
      *
      * \see LCDDataMode() LCDCommandMode() sendLCDCommand()
      */
-    void static SPItransfer(uint8_t data);
+    uint8_t static SPItransfer(uint8_t data);
 
     /** \brief
      * Turn the display off.


### PR DESCRIPTION
Added SYS_FLAG_POWERON_MENU This bit determines if Arduboy FX/Cathy3K bootloader starts with the built in loader menu (1) or last loaded application(0) afte switching power on

SPItransfer now returns the received SPI byte. This allowes the FX library to use SPItransfer from Arduboy2 library saving space.