### PR TITLE
Make cabi C++ compatible

### DIFF
--- a/extras/cabi/cabi.c
+++ b/extras/cabi/cabi.c
@@ -342,8 +342,8 @@ int main(int argc, char **argv)
 
 	rawlen = w * (h+7) / 8;
 
-	bmp0 = malloc(rawlen); memset(bmp0, 0, rawlen);
-	bmp1 = malloc(rawlen); memset(bmp1, 0, rawlen);
+	bmp0 = (unsigned char *)malloc(rawlen); memset(bmp0, 0, rawlen);
+	bmp1 = (unsigned char *)malloc(rawlen); memset(bmp1, 0, rawlen);
 
 	printf("// %s  width: %u height: %u\n", argv[1], w, h);
 


### PR DESCRIPTION
Casting the result of these calls to `malloc` should be all that is required to make cabi compilable as C++.
Without these casts cabi won't compile as C++, because in C++ `void *` is not implicitly convertible to other data types.
LodePNG already has C++ compatibility.