### PR TITLE
Add GitHub action for linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,10 @@
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update
+          compliance: strict


### PR DESCRIPTION
Create main.yml with Ardunio Linter.
https://github.com/arduino/arduino-lint-action#usage

This is a quick and easy addition. 
Not sure whether adding `cppcheck`, etc. would also be useful?