### PR TITLE
Optimize Arduboy2Base::drawFastVLine

### DIFF
--- a/src/Arduboy2.cpp
+++ b/src/Arduboy2.cpp
@@ -547,12 +547,28 @@ void Arduboy2Base::drawRect
 void Arduboy2Base::drawFastVLine
 (int16_t x, int16_t y, uint8_t h, uint8_t color)
 {
-  int end = y+h;
-  for (int a = max(0,y); a < min(end,HEIGHT); a++)
+  if (x < 0 || x >= WIDTH || y >= HEIGHT) return;
+
+  color = (color == WHITE ? ~0 : 0);
+
+  if (y < 0)
   {
-    drawPixel(x,a,color);
+    h += y;
+    y = 0;
   }
-}
+
+  int16_t end = y + h;
+
+  sBuffer[(y & 0xf8) * WIDTH / 8 + x] = color << (y - (y & 0xf8));
+
+  for (uint8_t i = max(y + 7, 0); i < min(end, HEIGHT); i += 8)
+  {
+    sBuffer[(i & 0xf8) * WIDTH / 8 + x] = color;
+  }
+
+  sBuffer[(min(end, HEIGHT - 1) & 0xf8) * WIDTH / 8 + x] = color >> (8 - (min(end, HEIGHT - 1) & 7));
+};
+
 
 void Arduboy2Base::drawFastHLine
 (int16_t x, int16_t y, uint8_t w, uint8_t color)

--- a/src/Arduboy2.cpp
+++ b/src/Arduboy2.cpp
@@ -558,15 +558,21 @@ void Arduboy2Base::drawFastVLine
   }
 
   int16_t end = y + h;
+  uint8_t data, colorUp = 0xff << (y - (y & 0xf8)),
+          colorDown = 0xff >> (8 - (min(end, HEIGHT - 1) & 7));
 
-  sBuffer[(y & 0xf8) * WIDTH / 8 + x] = color << (y - (y & 0xf8));
+  data = sBuffer[(y & 0xf8) * WIDTH / 8 + x] | colorUp;
+  if (!color) data ^= colorUp;
+  sBuffer[(y & 0xf8) * WIDTH / 8 + x] = data;
 
-  for (uint8_t i = max(y + 7, 0); i < min(end, HEIGHT); i += 8)
+  for (uint8_t i = max(y + 7, 0) & 0xf8; i <= min(end, HEIGHT - 1) - 7; i += 8)
   {
-    sBuffer[(i & 0xf8) * WIDTH / 8 + x] = color;
+    sBuffer[i * WIDTH / 8 + x] = color;
   }
 
-  sBuffer[(min(end, HEIGHT - 1) & 0xf8) * WIDTH / 8 + x] = color >> (8 - (min(end, HEIGHT - 1) & 7));
+  data = sBuffer[(min(end, HEIGHT - 1) & 0xf8) * WIDTH / 8 + x] | colorDown;
+  if (!color) data ^= colorDown;
+  sBuffer[(min(end, HEIGHT - 1) & 0xf8) * WIDTH / 8 + x] = data;
 };
 
 


### PR DESCRIPTION
Recently I ran into the problem of friezes in my game. By trial and error, I found out the reason - fillRect method. With a simple filling of the entire screen:
```c++
void loop() {
  ...
  arduboy.fillRect(0, 0, WIDTH, HEIGHT);
  Serial.println(arduboy.cpuLoad());
  ...
}
```

I discover, that cpu load reaches ~**80%**. The problem lies in the implementation of the `drawFastVLine` method, which needlessly redraws pixels individually, because you can save time by filling the entire byte at once.

Using this approach, I managed to lower cpu load to ~**10%** (*8x* acceleration)
On random data, the acceleration is *4x*

I know, that there are very worried about the size of the code, but here I can 't please: delta code size - **176** bytes (idk asm, but you probably can optimize this).

I don't know if you will add this, but it seems it would be useful for someone: [~200 lines (drawFastVLine)](https://github.com/search?q=arduboy.drawFastVLine&type=code) and [~800 lines (fillRect)](https://github.com/search?q=arduboy.fillRect&type=code)